### PR TITLE
add authentication option for service

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,27 @@ http://localhost:8080/swagger-ui.html
 ### Config file
 
 ```properties
-app.service_uri=http://localhost:8080 # sets URL for swagger UI
+# sets URL for swagger UI
+app.service_uri=http://localhost:8080
 
-cockpit.hostname=http://localhost:8081/ai-cockpit/ # URL for cockpit
-cockpit.moduleapi=api/module # context path module API
-cockpit.aicapi=api/aic/modules # context path AIC functions
+# URL for cockpit
+cockpit.hostname=http://localhost:8081/ai-cockpit/ 
+# context path module API
+cockpit.moduleapi=api/module
+# context path AIC functions
+cockpit.aicapi=api/aic/modules 
 
-scenario.setup=true # if true sample data will be send to cockpit
-scenario.importFolder=internal # if internal prepackaged data will be imported else folder location
+# if true sample data will be send to cockpit
+scenario.setup=true 
+# if internal prepackaged data will be imported else folder location
+scenario.importFolder=internal 
+
+# Authentication against IdP
+cockpit.auth.enabled=true
+cockpit.auth.client_id=aicockpit
+cockpit.auth.username=username 
+cockpit.auth.password=secret 
+cockpit.auth.url=https://hostname/auth/realms/default/protocol/openid-connect/token
 ```
 
 ## License

--- a/deployment/starwit-aicapi-transparency/templates/deployment.yaml
+++ b/deployment/starwit-aicapi-transparency/templates/deployment.yaml
@@ -64,12 +64,14 @@ spec:
               value: /scenariodata/data_structures/{{ .Values.sampledata.importFolder }}-{{ .Values.sampledata.language }}
             {{- end }}                       
             {{- if .Values.auth.enabled }}
-            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI
-              value: {{ .Values.auth.keycloak_url }}
-            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT-ID
+            - name: COCKPIT_AUTH_URL
+              value: {{ .Values.auth.auth_url }}
+            - name: COCKPIT_AUTH_CLIENT_ID
               value: {{ .Values.auth.client_id }}
-            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT-SECRET
-              value: {{ .Values.auth.client_secret }}
+            - name: COCKPIT_AUTH_USERNAME
+              value: {{ .Values.auth.username }}
+            - name: COCKPIT_AUTH_PASSWORD
+              value: {{ .Values.auth.password }}
             {{- else }}
             - name: SPRING_PROFILES_ACTIVE
               value: default

--- a/deployment/starwit-aicapi-transparency/values.yaml
+++ b/deployment/starwit-aicapi-transparency/values.yaml
@@ -17,9 +17,11 @@ app:
 
 auth:
   enabled: false
-  keycloak_url: https://hostname/realms/aicockpit
+  auth_url: https://hostname/realms/aicockpit/protocol/openid-connect/token
   client_id: aicockpit
-  client_secret: aicockpit 
+  username: apiuser
+  password: apiuser
+
 
 sampledata:
   enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.2</version>
+        <version>3.4.3</version>
         <relativePath />
     </parent>
 
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <openapi-version>2.8.4</openapi-version>
+        <openapi-version>2.8.5</openapi-version>
         <aicockpit-api>0.1.0</aicockpit-api>
     </properties>
 
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools</groupId>
@@ -89,6 +89,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.4</version>
+          </dependency>
     </dependencies>
 
     <build>
@@ -239,7 +244,7 @@
             <plugin>
                 <groupId>se.bjurr.gitchangelog</groupId>
                 <artifactId>git-changelog-maven-plugin</artifactId>
-                <version>2.2.4</version>
+                <version>2.2.5</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.openjdk.nashorn</groupId>

--- a/src/main/java/de/starwit/services/AuthService.java
+++ b/src/main/java/de/starwit/services/AuthService.java
@@ -1,0 +1,101 @@
+package de.starwit.services;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+public class AuthService {
+
+    Logger log = LoggerFactory.getLogger(AuthService.class);
+
+    @Value("${cockpit.auth.client_id:aicockpit}")
+    private String clientId;
+
+    @Value("${cockpit.auth.username}")
+    private String username;
+
+    @Value("${cockpit.auth.password}")
+    private String password;
+    
+    @Value("${cockpit.auth.url}")
+    private String authUrl;
+
+    private LocalDateTime tokenTimeStamp;
+    
+    private String token = null;
+
+    @Autowired
+    private RestTemplate restTemplate;
+    
+    @Autowired
+    private ObjectMapper mapper;
+
+    public void getAccessToken() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> map= new LinkedMultiValueMap<String, String>();
+        map.add("realm", "default");
+        map.add("client_id", clientId);
+        map.add("grant_type", "password"); 
+        map.add("username", username);
+        map.add("password", password);        
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(map, headers);
+        HttpEntity<String> response;
+        try {
+            response = restTemplate.postForEntity(authUrl, request, String.class);
+        } catch (HttpClientErrorException e) {
+            log.error("Can't get access token for user " + username + " with error: " + e.getMessage());
+            token = null;
+            return;
+        }
+
+        mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        try {
+            AuthTokenResponse authResponse = mapper.readValue(response.getBody(), AuthTokenResponse.class);
+            token = authResponse.getAccessToken();
+            tokenTimeStamp = LocalDateTime.now();
+            log.debug("Token succesfully loaded");
+        } catch (JsonProcessingException e) {
+            log.error("Can't parse auth response " + e.getMessage());
+        }
+    }
+
+    private void checkIfTokenIsStillValid() {
+        if(token == null) {
+            getAccessToken();
+        } else {
+            LocalDateTime now = LocalDateTime.now();
+            long diff = ChronoUnit.MILLIS.between(tokenTimeStamp, now);
+            log.debug("Token age " + diff);
+            // token is too old, try again to aqcuire one
+            if(diff > 2590000) {
+                log.debug("Token too old, get a new one");
+                getAccessToken();
+            }
+        }
+    }
+
+    public String getToken() {
+        checkIfTokenIsStillValid();
+        return token;
+    }    
+}

--- a/src/main/java/de/starwit/services/AuthTokenResponse.java
+++ b/src/main/java/de/starwit/services/AuthTokenResponse.java
@@ -1,0 +1,78 @@
+package de.starwit.services;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthTokenResponse {
+    
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+
+    @JsonProperty("refresh_expires_in")
+    private int refreshExpiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("not-before-policy")
+    private int notBeforePolicy;
+
+    @JsonProperty("session_state")
+    private String sessionState;
+
+    private String scope;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+    public void setExpiresIn(int expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+    public int getRefreshExpiresIn() {
+        return refreshExpiresIn;
+    }
+    public void setRefreshExpiresIn(int refreshExpiresIn) {
+        this.refreshExpiresIn = refreshExpiresIn;
+    }
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+    public String getTokenType() {
+        return tokenType;
+    }
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+    public int getNotBeforePolicy() {
+        return notBeforePolicy;
+    }
+    public void setNotBeforePolicy(int notBeforePolicy) {
+        this.notBeforePolicy = notBeforePolicy;
+    }
+    public String getSessionState() {
+        return sessionState;
+    }
+    public void setSessionState(String sessionState) {
+        this.sessionState = sessionState;
+    }
+    public String getScope() {
+        return scope;
+    }
+    public void setScope(String scope) {
+        this.scope = scope;
+    }    
+}

--- a/src/main/java/de/starwit/services/ModuleDataService.java
+++ b/src/main/java/de/starwit/services/ModuleDataService.java
@@ -31,7 +31,7 @@ public class ModuleDataService {
     Logger log = LoggerFactory.getLogger(ModuleDataService.class);
 
     @Autowired
-    ModuleSynchronizationService moduleNotificationService;
+    ModuleSynchronizationService moduleSynchService;
 
     /**
      * This is the URI under which this API will deliver sboms, if hosted here.
@@ -72,14 +72,14 @@ public class ModuleDataService {
             Module[] mods = mapper.readValue(inputStream, Module[].class);
             updateUris(mods);
             for (Module module : mods) {
-                var validation = moduleNotificationService.validateModuleData(module);
+                var validation = moduleSynchService.validateModuleData(module);
                 log.info("Validation result : " + validation.toString());
-                if (moduleNotificationService.checkIfModuleExists(module.getName())) {
-                    log.info("Module with name {} already exists", module.getName());
+                if (moduleSynchService.checkIfModuleExists(module.getName())) {
+                    log.info("Module with name {} already exists or cockpit is unreachable", module.getName());
                     continue;
                 } else {
                     log.info("Registering module {}", module.getName());
-                    moduleNotificationService.synchModuleData(module);
+                    moduleSynchService.synchModuleData(module);
                 }
             }
         } catch (IOException e) {
@@ -109,7 +109,7 @@ public class ModuleDataService {
                 var mods = mapper.readValue(file, new TypeReference<List<Module>>() {
                 });
                 for (Module module : mods) {
-                    moduleNotificationService.synchModuleData(module);
+                    moduleSynchService.synchModuleData(module);
                 }
             } catch (IOException e) {
                 log.error("Error reading scenario data" + e.getMessage());

--- a/src/main/java/de/starwit/services/ModuleSynchronizationService.java
+++ b/src/main/java/de/starwit/services/ModuleSynchronizationService.java
@@ -11,8 +11,13 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -36,7 +41,13 @@ public class ModuleSynchronizationService {
     @Value("${cockpit.aicapi:api/aic/modules}")
     private String aicAPI;
 
+    @Value("${cockpit.auth.enabled:false}")
+    private boolean authEnabled;    
+
     private final RestTemplate restTemplate;
+
+    @Autowired
+    AuthService authService;
 
     public ModuleSynchronizationService(RestTemplateBuilder builder) {
         this.restTemplate = builder.build();
@@ -46,10 +57,20 @@ public class ModuleSynchronizationService {
     public void synchModuleData(Module module) {
         try {
             log.info("Sending new module to Cockpit: " + cockpitHostname + aicAPI);
-            log.info(module.toString());
-            ResponseEntity<String> resp = restTemplate.postForEntity(cockpitHostname + aicAPI, module,
-                    String.class);
-            log.info(resp.getBody());
+            log.debug(module.toString());
+            String response = "";
+            
+            if(authEnabled) {
+                HttpEntity<Module> httpEntity = prepareHTTPEntity(module);
+                ResponseEntity<String> resp = restTemplate.postForEntity(cockpitHostname + aicAPI, httpEntity,
+                        String.class);
+                response =  resp.getBody();
+            } else {
+                ResponseEntity<String> resp = restTemplate.postForEntity(cockpitHostname + aicAPI, module,
+                        String.class);
+                response =  resp.getBody();
+            }
+            log.info(response);
         } catch (Exception ex) {
             log.error("Failed to synch module to cockpit: " + ex.getMessage());
         }
@@ -59,7 +80,13 @@ public class ModuleSynchronizationService {
         List<Module> modules = new LinkedList<>();
         try {
             log.debug("Loading existing modules from cockpit: " + cockpitHostname + aicAPI);
-            ResponseEntity<Module[]> resp = restTemplate.getForEntity(cockpitHostname + aicAPI, Module[].class);
+            ResponseEntity<Module[]> resp;
+            if(authEnabled) {
+                HttpEntity<String> httpEntity = prepareHTTPEntity("");
+                resp = restTemplate.exchange(cockpitHostname + aicAPI, HttpMethod.GET, httpEntity, Module[].class);
+            } else {
+                resp = restTemplate.getForEntity(cockpitHostname + aicAPI, Module[].class);
+            }
             modules = List.of(resp.getBody());
         } catch (Exception ex) {
             log.error("Failed to load existing modules from cockpit: " + ex.getMessage());
@@ -75,22 +102,40 @@ public class ModuleSynchronizationService {
                 .buildAndExpand(name)
                 .toUri();
             log.debug(uri.toString());
-            ResponseEntity<Module> resp = restTemplate
-                    .getForEntity(uri, Module.class);
-            log.debug("Result of existence test " + resp.getStatusCode().toString());
+            ResponseEntity<Module> resp;
+            if(authEnabled) {
+                HttpEntity<String> httpEntity = prepareHTTPEntity("");
+                resp = restTemplate.exchange(uri, HttpMethod.GET, httpEntity, Module.class);
+            } else {
+                resp = restTemplate.getForEntity(uri, Module.class);
+            }
+            
+            log.info("Result of existence test " + resp.getStatusCode().toString());
             if (resp.getStatusCode().is2xxSuccessful()) {
                 return true;
             } else {
                 return false;
             }
         } catch (HttpClientErrorException ex) {
-            log.debug("Module does not exist yet: " + ex.getStatusCode());
-            return false;
+            log.info("Existence test for module resulted in response code " + ex.getStatusCode());
+            if (ex.getStatusCode().equals(HttpURLConnection.HTTP_NOT_FOUND)) {
+                log.info("Module does not exist yet");
+                return false;
+            }
+            return true;
         }
         catch (Exception ex) {
             log.error("Failed to test if module exists: " + ex.getMessage());
             return true;
         }
+    }
+
+    private <T> HttpEntity<T> prepareHTTPEntity(T entity) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization","Bearer " + authService.getToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<T> httpEntity = new HttpEntity<>(entity, headers);
+        return httpEntity;
     }
 
     public ValidationFeedback validateModuleData(Module module) {

--- a/src/main/java/org/openapitools/OpenApiGeneratorApplication.java
+++ b/src/main/java/org/openapitools/OpenApiGeneratorApplication.java
@@ -7,7 +7,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication(
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
@@ -27,5 +29,15 @@ public class OpenApiGeneratorApplication {
     public Module jsonNullableModule() {
         return new JsonNullableModule();
     }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(3000);
+
+        restTemplate.setRequestFactory(requestFactory);
+        return restTemplate;
+    }    
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,10 @@ cockpit.aicapi=api/aic/modules
 scenario.setup=true
 # if internal prepackaged data will be imported else folder location
 scenario.importFolder=internal
+
+# Authentication
+cockpit.auth.enabled=true
+cockpit.auth.client_id=aicockpit
+cockpit.auth.username=username 
+cockpit.auth.password=secret 
+cockpit.auth.url=https://hostname/auth/realms/default/protocol/openid-connect/token


### PR DESCRIPTION
If Cockpit is running behind an IdP authentication, service can configured to use access token.

## Description
Application properties can now contain authentication coordinates, which will be used to authenticate requests against cockpit.

## Motivation and Context
Live instances of cockpit will be secured.

## How has this been tested?
Against local Cockpit installations with/out auth.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
